### PR TITLE
Automated Releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor/*
 
 # Compiled binary
 tmpltr
+.out/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,18 @@ install:
 script:
   - make check
 
+before_deploy:
+  - go get github.com/tcnksm/ghr
+  - go get github.com/mitchellh/gox
+
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: make release
+    on:
+      tags: true
+      condition: $TRAVIS_GO_VERSION =~ ^1\.8\.[0-9]+$
+
 cache:
   directories:
     - ~/.glide/cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,9 @@ install:
 script:
   - make check
 
+cache:
+  directories:
+    - ~/.glide/cache/
+
 notifications:
   email: false


### PR DESCRIPTION
Two changes here. The first just enable caching of the glide dependencies in the travis-ci config. This should speed up builds on the same branch. The second automates the release process. If a commit has been tagged travis will cross compile (on the 1.8) the application and uploads the binaries to the github release for that tag.

